### PR TITLE
Add link to eemeli/IntlPluralRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ __Stage 0__
 
 Implementation Progress
 
- * Polyfill (in progress)
+ * Polyfill: https://github.com/eemeli/IntlPluralRules
 
 Backpointers
 


### PR DESCRIPTION
So... I sort of did a polyfill for the current spec, here: https://github.com/eemeli/IntlPluralRules

As mentioned in its [release notes](https://github.com/eemeli/IntlPluralRules/releases/tag/v0.1.0), it doesn't follow the current spec exactly:
- `#select()` input is not forced to Number, so e.g. 1.0 is handled correctly
- `availableLocales` is determined by taking into account `options.style`, as ordinal rules are not provided for all locales by the Unicode CLDR
- `options.localeMatcher` is ignored

The two first divergences are proposed solutions for #1; the last is due to there being really only one algorithm that seemed to make any sense for locale matching.

I wrote this in ES2015, and it's packaged using an UMD pattern, so it should be usable in most places. Aside from the Travis CI tests, however, I have not tested it in other browsers than Chrome 45.
