### PR TITLE
Fix mistakes in variables names & types

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -46,9 +46,9 @@
     </emu-clause>
 
     <emu-clause id="sec-GetOperands" aoid="GetOperands">
-       <h1>GetOperands (x)</h1>
+       <h1>GetOperands (s)</h1>
        <p>
-         When the GetOperands abstract operation is called with argument _n_ (which must be a finite Number value), it returns an Object value with the list of plural operands used by plural rules functions.
+         When the GetOperands abstract operation is called with argument _s_ (which must be a String matching the regular expression pattern `-?\d*(\.\d*)?`, it returns an Object value with the list of plural operands used by plural rules functions.
        </p>
 
        <p>
@@ -56,10 +56,8 @@
        </p>
 
        <emu-alg>
+         1. Let _n_ be ? ToNumber(_s_).
          1. Assert: Type(_n_) is a Number, and _n_ is finite.
-         1. If _n_ < 0, then
-           1. Let _n_ be abs(_n_).
-         1. Let _s_ be ? ToString(_n_).
          1. Let _dp_ be ? Call(%StringProto_indexOf%, _s_, « `"."` »).
          1. If _dp_ = -1, then
            1. Set _iv_ to _n_.
@@ -70,7 +68,7 @@
            1. Let _fv_ be the substring of _s_ from position _dp_, exclusive.
            1. Let _f_ be ? ToNumber(_fv_).
            1. Let _v_ be ? ToLength(? Get(_fv_, *"length"*)).
-         1. Let _i_ be ? ToNumber(_iv_).
+         1. Let _i_ be ? abs(? ToNumber(_iv_)).
          1. If _f_ ≠ 0, then
            1. Let _ft_ be the value of _fv_ stripped of trailing *"0"*.
            1. Let _w_ be ? ToLength(? Get(_ft_, *"length"*)).
@@ -137,7 +135,7 @@
     </emu-clause>
 
     <emu-clause id="sec-ResolvePlural" aoid="ResolvePlural">
-      <h1>ResolvePlural (pluralRules, x)</h1>
+      <h1>ResolvePlural (pluralRules, n)</h1>
       <p>
         When the ResolvePlural abstract operation is called with arguments _pluralRules_ (which must be an object initialized as a PluralRules) and _n_ (which must be a Number value), it returns a String value representing the plural form of _n_ according to the effective locale and the options of _pluralRules_.
       </p>
@@ -152,12 +150,12 @@
         1. If isFinite(_n_) is *false*, then
           1. Return *"other"*.
         1. If the _pluralRules_.[[MinimumSignificantDigits]] is not *undefined* and _pluralRules_.[[MaximumSignificantDigits]] is not *undefined*, then
-          1. Let _n_ be ToRawPrecision(_n_, _pluralRules_.[[MinimumSignificantDigits]], _pluralRules_.[[MaximumSignificantDigits]]).
+          1. Let _s_ be ToRawPrecision(_n_, _pluralRules_.[[MinimumSignificantDigits]], _pluralRules_.[[MaximumSignificantDigits]]).
         1. Else,
-          1. Let _n_ be ToRawFixed(_n_, _pluralRules_.[[MinimumIntegerDigits]], _pluralRules_.[[MinimumFractionDigits]], _pluralRules_.[[MaximumFractionDigits]]).
+          1. Let _s_ be ToRawFixed(_n_, _pluralRules_.[[MinimumIntegerDigits]], _pluralRules_.[[MinimumFractionDigits]], _pluralRules_.[[MaximumFractionDigits]]).
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].
-        1. Let _operands_ be ? _GetOperands_(_n_).
+        1. Let _operands_ be ? _GetOperands_(_s_).
         1. Return ? PluralRuleSelection(_locale_, _type_, _n_, _operands_).
       </emu-alg>
 
@@ -292,7 +290,7 @@
         1. Let _pluralRules_ be *this* value.
         1. If Type(_pluralRules_) is not Object or _pluralRules_ does not have an [[InitializedPluralRules]] internal slot whose value is *true*, throw a TypeError exception.
         1. If _value_ is not provided, let _value_ be *undefined*.
-        1. Let _n_ be ? ToNumber(_x_).
+        1. Let _n_ be ? ToNumber(_value_).
         1. Return ? ResolvePlural(_pluralRules_, _n_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Some of the variable names and types didn't match each other; this fixes them.

Also fixed: the input to GetOperands is a String, rather than a number.
