### PR TITLE
 SetNumberFormatDigitOptions is fallible when provided a user-controllable options object, so invoke it as such.

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -24,7 +24,7 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Perform ! SetNumberFormatOptions(_pluralRules_, _options_, *0*).
+        1. Perform ? SetNumberFormatOptions(_pluralRules_, _options_, *0*).
         1. If _pluralRules_.[[maximumFractionDigits]] is *undefined*, then
           1. Set _pluralRules_.[[maximumFractionDigits]] to max(_pluralRules_.[[minimumFractionDigits]], 3).
         1. Let _r_ be ResolveLocale(*%PluralRules%*.[[AvailableLocales]], _requestedLocales_, _opt_).


### PR DESCRIPTION
Following https://github.com/tc39/ecma402/commit/947aa9a0c853422824a0c9510d8f09be3eb416b9