### PR TITLE
Normative: Set [[PluralCategories]] appropriately in the constructor

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -27,6 +27,8 @@
         1. Perform ? SetNumberFormatOptions(_pluralRules_, _options_, *0*, *3*).
         1. Let _r_ be ResolveLocale(*%PluralRules%*.[[AvailableLocales]], _requestedLocales_, _opt_).
         1. Set _pluralRules_.[[Locale]] to the value of _r_.[[Locale]].
+        1. Let _pluralCategories_ be a List of Strings representing the possible results of plural selection.
+        1. Set _pluralRules_.[[PluralCategories]] to CreateArrayFromList(_pluralCategories_).
         1. Set _pluralRules_.[[InitializedPluralRules]] to *true*.
         1. Return _pluralRules_.
       </emu-alg>


### PR DESCRIPTION
This patch makes resolvedOptions().pluralCategories work, but it
returns the same Array each time, rather than cloning. Cloning could
be added later in resolvedOptions() if desired.

Closes #28