### PR TITLE
Editorial: Remove extraneous style mention

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -277,7 +277,7 @@
         This function provides access to the locale and options computed during initialization of the object.
       </p>
       <p>
-        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this PluralRules object. (see <emu-xref href="#sec-properties-of-intl-pluralrules-instances"></emu-xref>): locale, type, style, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, and pluralCategories. Properties whose corresponding internal slots are not present are not assigned.
+        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this PluralRules object. (see <emu-xref href="#sec-properties-of-intl-pluralrules-instances"></emu-xref>): locale, type, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, and pluralCategories. Properties whose corresponding internal slots are not present are not assigned.
       </p>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This is from resolvedOptions, which already removes the type

Closes #27