### PR TITLE
Final editorial adjustments before merging this into 402

### DIFF
--- a/spec/pluralrules.html
+++ b/spec/pluralrules.html
@@ -4,39 +4,36 @@
   <emu-clause id="sec-intl-pluralrules-abstracts">
     <h1>Abstract Operations for PluralRules Objects</h1>
 
-    <emu-clause id="sec-InitializePluralRules" aoid="InitializePluralRules">
-      <h1>InitializePluralRules (pluralRules, locales, options)</h1>
+    <emu-clause id="sec-initializepluralrules" aoid="InitializePluralRules">
+      <h1>InitializePluralRules ( _pluralRules_, _locales_, _options_ )</h1>
 
       <p>
-        The abstract operation InitializePluralRules accepts the arguments _pluralRules_ (which must be an object), _locales_, and _options_. It initializes _pluralRules_ as a PluralRules object. It performs the following steps:
+        The abstract operation InitializePluralRules accepts the arguments _pluralRules_ (which must be an object), _locales_, and _options_. It initializes _pluralRules_ as a PluralRules object. The following steps are taken
       </p>
 
       <emu-alg>
-        1. If _pluralRules_.[[InitializedIntlObject]] is *true*, throw a *TypeError* exception.
-        1. Set _pluralRules_.[[InitializedIntlObject]] to *true*.
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
-          1. Let _options_ be ObjectCreate(*%ObjectPrototype%*).
+          1. Let _options_ be ObjectCreate(*null*).
         1. Else
           1. Let _options_ be ? ToObject(_options_).
-        1. Let _t_ be ? GetOption(_options_, *"type"*, *"string"*, « *"cardinal"*, *"ordinal"* », *"cardinal"*).
+        1. Let _t_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"cardinal"`, `"ordinal"` &raquo;, `"cardinal"`).
         1. Set _pluralRules_.[[Type]] to _t_.
         1. Let _opt_ be a new Record.
-        1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).
+        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Perform ? SetNumberFormatOptions(_pluralRules_, _options_, *0*, *3*).
-        1. Let _r_ be ResolveLocale(*%PluralRules%*.[[AvailableLocales]], _requestedLocales_, _opt_).
+        1. Let _r_ be ResolveLocale(%PluralRules%.[[AvailableLocales]], _requestedLocales_, _opt_).
         1. Set _pluralRules_.[[Locale]] to the value of _r_.[[Locale]].
         1. Let _pluralCategories_ be a List of Strings representing the possible results of plural selection.
         1. Set _pluralRules_.[[PluralCategories]] to CreateArrayFromList(_pluralCategories_).
-        1. Set _pluralRules_.[[InitializedPluralRules]] to *true*.
         1. Return _pluralRules_.
       </emu-alg>
 
     </emu-clause>
 
-    <emu-clause id="sec-GetOperands" aoid="GetOperands">
-       <h1>GetOperands (s)</h1>
+    <emu-clause id="sec-getoperands" aoid="GetOperands">
+       <h1>GetOperands ( _s_ )</h1>
        <p>
          When the GetOperands abstract operation is called with argument _s_. It performs the following steps:
        </p>
@@ -45,7 +42,7 @@
          1. Assert: Type(_s_) is String.
          1. Let _n_ be ? ToNumber(_s_).
          1. Assert: _n_ is finite.
-         1. Let _dp_ be ? Call(%StringProto_indexOf%, _s_, « `"."` »).
+         1. Let _dp_ be ? Call(%StringProto_indexOf%, _s_, &laquo; `"."` &raquo;).
          1. If _dp_ = -1, then
            1. Set _iv_ to _n_.
            1. Let _f_ be 0.
@@ -54,11 +51,11 @@
            1. Let _iv_ be the substring of _s_ from position 0, inclusive, to position _dp_, exclusive.
            1. Let _fv_ be the substring of _s_ from position _dp_, exclusive.
            1. Let _f_ be ? ToNumber(_fv_).
-           1. Let _v_ be ? ToLength(? Get(_fv_, *"length"*)).
+           1. Let _v_ be ? ToLength(? Get(_fv_, `"length"`)).
          1. Let _i_ be ? abs(? ToNumber(_iv_)).
          1. If _f_ ≠ 0, then
-           1. Let _ft_ be the value of _fv_ stripped of trailing *"0"*.
-           1. Let _w_ be ? ToLength(? Get(_ft_, *"length"*)).
+           1. Let _ft_ be the value of _fv_ stripped of trailing `"0"`.
+           1. Let _w_ be ? ToLength(? Get(_ft_, `"length"`)).
            1. Let _t_ be ? ToNumber(_ft_).
          1. Else,
            1. Let _w_ be 0.
@@ -79,7 +76,7 @@
            <tr>
              <td>[[Number]]</td>
              <td>Number</td>
-             <td>absolute value of the source number (integer and decimals)</td>
+             <td>Absolute value of the source number (integer and decimals)</td>
            </tr>
            <tr>
              <td>[[IntegerDigits]]</td>
@@ -113,29 +110,26 @@
 
     <emu-clause id="sec-pluralruleselection" aoid="PluralRuleSelection">
 
-      <h1>PluralRuleSelection (locale, type, n, operands)</h1>
+      <h1>PluralRuleSelection ( _locale_, _type_, _n_, _operands_ )</h1>
 
       <p>
-        When the PluralRuleSelection abstract operation is called with four arguments, it performs implementation dependent algorithm to map _n_ to the appropriate plural representation of the Operand Record _operands_ by selecting the rules denoted by _type_ for the corresponding _locale_, or the String value *"other"*.
+        When the PluralRuleSelection abstract operation is called with four arguments, it performs implementation dependent algorithm to map _n_ to the appropriate plural representation of the Operand Record _operands_ by selecting the rules denoted by _type_ for the corresponding _locale_, or the String value `"other"`.
       </p>
 
     </emu-clause>
 
-    <emu-clause id="sec-ResolvePlural" aoid="ResolvePlural">
-      <h1>ResolvePlural (pluralRules, n)</h1>
+    <emu-clause id="sec-resolveplural" aoid="ResolvePlural">
+      <h1>ResolvePlural ( _pluralRules_, _n_ )</h1>
       <p>
-        When the ResolvePlural abstract operation is called with arguments _pluralRules_ (which must be an object initialized as a PluralRules) and _n_ (which must be a Number value), it returns a String value representing the plural form of _n_ according to the effective locale and the options of _pluralRules_.
-      </p>
-
-      <p>
-        The following steps are taken:
+        When the ResolvePlural abstract operation is called with arguments _pluralRules_ (which must be an object initialized as a PluralRules) and _n_ (which must be a Number value), it returns a String value representing the plural form of _n_ according to the effective locale and the options of _pluralRules_. The following steps are taken:
       </p>
 
       <emu-alg>
-        1. Assert: Type(_pluralRules_) is Object and _pluralRules_ has an [[InitializedPluralRules]] internal slot whose value is *true*.
+        1. Assert: Type(_pluralRules_) is Object.
+        1. Assert: If _pluralRules_ does not have an [[InitializedPluralRules]] internal slot, throw a *TypeError* exception.
         1. Assert: Type(_n_) is Number.
         1. If isFinite(_n_) is *false*, then
-          1. Return *"other"*.
+          1. Return `"other"`.
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].
         1. Let _s_ be ? FormatNumberToString(_pluralRules_, _n_).
@@ -154,16 +148,16 @@
       The PluralRules constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
-    <emu-clause id="sec-Intl.PluralRules">
-      <h1>Intl.PluralRules ([ locales [ , options ]])</h1>
+    <emu-clause id="sec-intl.pluralrules">
+      <h1>Intl.PluralRules ( [ _locales_ [ , _options_ ] ] )</h1>
 
       <p>
-        When the *Intl.PluralRules* function is called with optional arguments the following steps are taken:
+        When the `Intl.PluralRules` function is called with optional arguments, the following steps are taken:
       </p>
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(_newTarget_, *%PluralRulesPrototype%*).
+        1. Let _pluralRules_ be ? OrdinaryCreateFromConstructor(_newTarget_, %PluralRulesPrototype%).
         1. Return ? InitializePluralRules(_pluralRules_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -176,36 +170,36 @@
       The Intl.PluralRules constructor has the following properties:
     </p>
 
-    <emu-clause id="sec-Intl.PluralRules.prototype">
+    <emu-clause id="sec-intl.pluralrules.prototype">
       <h1>Intl.PluralRules.prototype</h1>
 
       <p>
-        The value of *Intl.PluralRules.prototype* is *%PluralRulesPrototype%*.
+        The value of `Intl.PluralRules.prototype` is %PluralRulesPrototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.PluralRules.supportedLocalesOf">
-      <h1>Intl.PluralRules.supportedLocalesOf (locales [, options ])</h1>
+    <emu-clause id="sec-intl.pluralrules.supportedlocalesof">
+      <h1>Intl.PluralRules.supportedLocalesOf ( _locales_ [, _options_ ] )</h1>
 
       <p>
-        When the *supportedLocalesOf* method of *%PluralRules%* is called, the following steps are taken:
+        When the `supportedLocalesOf` method is called with arguments _locales_ and _options_, the following steps are taken:
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be *%PluralRules%*.[[AvailableLocales]].
+        1. Let _availableLocales_ be %PluralRules%.[[AvailableLocales]].
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
 
       <p>
-        The value of the *length* property of the *supportedLocalesOf* method is 1.
+        The value of the `length` property of the *supportedLocalesOf* method is 1.
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.PluralRules-internal-slots">
+    <emu-clause id="sec-intl.pluralrules-internal-slots">
       <h1>Internal slots</h1>
 
       <p>
@@ -231,55 +225,110 @@
     <h1>Properties of the Intl.PluralRules Prototype Object</h1>
 
     <p>
-      The Intl.PluralRules prototype object is itself an ordinary object. %PluralRulesPrototype% is not an Intl.PluralRules instance and does not have an [[InitializedPluralRules]] internal slot or any of the other internal slots of Intl.PluralRules instance objects.
+      The Intl.PluralRules prototype object is itself an ordinary object. <dfn>%PluralRulesPrototype%</dfn> is not an Intl.PluralRules instance and does not have an [[InitializedPluralRules]] internal slot or any of the other internal slots of Intl.PluralRules instance objects.
     </p>
     <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of *%PluralRulesPrototype%*, the phrase "this PluralRules object" refers to the object that is the this  value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedPluralRules]] internal slot with value *true*.
+      In the following descriptions of functions that are properties or [[Get]] attributes of properties of %PluralRulesPrototype%, the phrase "this PluralRules object" refers to the object that is the this  value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object that does not have an [[InitializedPluralRules]] internal slot.
     </p>
 
-    <emu-clause id="sec-Intl.PluralRules.prototype.constructor">
+    <emu-clause id="sec-intl.pluralrules.prototype.constructor">
       <h1>Intl.PluralRules.prototype.constructor</h1>
 
       <p>
-        The initial value of *Intl.PluralRules.prototype.constructor* is *%PluralRules%*.
+        The initial value of `Intl.PluralRules.prototype.constructor` is %PluralRules%.
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.PluralRules.prototype-toStringTag">
+    <emu-clause id="sec-intl.pluralrules.prototype-tostringtag">
       <h1>Intl.PluralRules.prototype [ @@toStringTag ]</h1>
 
       <p>
-        The initial value of the @@toStringTag property is the string value *"Object"*.
+        The initial value of the @@toStringTag property is the string value `"Object"`.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.PluralRules.prototype.select">
-      <h1>Intl.PluralRules.prototype.select( value )</h1>
+    <emu-clause id="sec-intl.pluralrules.prototype.select">
+      <h1>Intl.PluralRules.prototype.select( _value_ )</h1>
 
       <p>
-        When the *Intl.PluralRules.prototype.select* is called with an argument _value_, the following steps are taken:
+        When the `select` is called with an argument _value_, the following steps are taken:
       </p>
 
       <emu-alg>
-        1. Let _pluralRules_ be *this* value.
-        1. If Type(_pluralRules_) is not Object or _pluralRules_ does not have an [[InitializedPluralRules]] internal slot whose value is *true*, throw a TypeError exception.
+        1. Let _pr_ be *this* value.
+        1. If Type(_pr_) is not Object, throw a *TypeError* exception.
+        1. If _pr_ does not have an [[InitializedPluralRules]] internal slot, throw a *TypeError* exception.
         1. Let _n_ be ? ToNumber(_value_).
-        1. Return ? ResolvePlural(_pluralRules_, _n_).
+        1. Return ? ResolvePlural(_pr_, _n_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.PluralRules.prototype.resolvedOptions">
+    <emu-clause id="sec-intl.pluralrules.prototype.resolvedoptions">
       <h1>Intl.PluralRules.prototype.resolvedOptions ()</h1>
 
       <p>
         This function provides access to the locale and options computed during initialization of the object.
       </p>
-      <p>
-        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this PluralRules object. (see <emu-xref href="#sec-properties-of-intl-pluralrules-instances"></emu-xref>): locale, type, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, and pluralCategories. Properties whose corresponding internal slots are not present are not assigned.
-      </p>
+
+      <emu-alg>
+        1. Let _pr_ be *this* value.
+        1. If Type(_pr_) is not Object, throw a *TypeError* exception.
+        1. If _pr_ does not have an [[InitializedPluralRules]] internal slot, throw a *TypeError* exception.
+        1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
+        1. For each row of <emu-xref href="#table-pluralrules-resolvedoptions-properties"></emu-xref>, except the header row, do
+          1. Let _p_ be the Property value of the current row.
+          1. Let _v_ be the value of _pr_'s internal slot whose name is the Internal Slot value of the current row.
+          1. If _v_ is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
+        1. Return _options_.
+      </emu-alg>
+
+      <emu-table id="table-pluralrules-resolvedoptions-properties">
+        <emu-caption>Resolved Options of PluralRules Instances</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>[[Locale]]</td>
+            <td>"locale"</td>
+          </tr>
+          <tr>
+            <td>[[Type]]</td>
+            <td>"type"</td>
+          </tr>
+          <tr>
+            <td>[[MinimumIntegerDigits]]</td>
+            <td>"minimumIntegerDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MinimumFractionDigits]]</td>
+            <td>"minimumFractionDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MaximumFractionDigits]]</td>
+            <td>"maximumFractionDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MinimumSignificantDigits]]</td>
+            <td>"minimumSignificantDigits"</td>
+          </tr>
+          <tr>
+            <td>[[MaximumSignificantDigits]]</td>
+            <td>"maximumSignificantDigits"</td>
+          </tr>
+          <tr>
+            <td>[[PluralCategories]]</td>
+            <td>"pluralCategories"</td>
+          </tr>
+        </table>
+      </emu-table>
     </emu-clause>
   </emu-clause>
 
@@ -287,24 +336,24 @@
     <h1>Properties of Intl.PluralRules Instances</h1>
 
     <p>
-      Intl.PluralRules instances inherit properties from *%PluralRulesPrototype%*.
+      Intl.PluralRules instances inherit properties from %PluralRulesPrototype%.
     </p>
 
     <p>
-      Intl.PluralRules instances and other objects that have been successfully initialized as a PluralRules have [[InitializedIntlObject]] and [[InitializedPluralRules]] internal slots whose values are *true*.
+      Intl.PluralRules instances have an [[InitializedPluralRules]] internal slots.
     </p>
 
     <p>
-      Objects that have been successfully initialized as a PluralRules object also have several internal slots that are computed by the constructor:
+      Intl.PluralRules instances also have several internal slots that are computed by the constructor:
     </p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the plural rules.</li>
-      <li>[[Type]] is one of the String values *"cardinal"*, or *"ordinal"*, identifying the plural rules used.</li>
-      <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used. Numbers will be padded with leading zeroes if necessary.</li>
+      <li>[[Type]] is one of the String values `"cardinal"`, or `"ordinal"`, identifying the plural rules used.</li>
+      <li>[[MinimumIntegerDigits]] is a non-negative integer Number value indicating the minimum integer digits to be used.</li>
       <li>[[MinimumFractionDigits]] and [[MaximumFractionDigits]] are non-negative integer Number values indicating the minimum and maximum fraction digits to be used. Numbers will be rounded or padded with trailing zeroes if necessary.</li>
-      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be shown. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits – the formatter uses however many integer and fraction digits are required to display the specified number of significant digits.</li>
-      <li>[[PluralCategories]] is an array of unique string values, from the the list *"zero"*, *"one"*, *"two"*, *"few"*, *"many"* and *"other"*, that are relevant for the locale whose localization is specified in LDML Language Plural Rules.</li>
+      <li>[[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive integer Number values indicating the minimum and maximum fraction digits to be used. Either none or both of these properties are present; if they are, they override minimum and maximum integer and fraction digits.</li>
+      <li>[[PluralCategories]] is an array of unique string values, from the the list `"zero"`, `"one"`, `"two"`, `"few"`, `"many"` and `"other"`, that are relevant for the locale whose localization is specified in LDML Language Plural Rules.</li>
     </ul>
 
   </emu-clause>


### PR DESCRIPTION
* `sec` should be lowercased
* adjusting arguments, intrinsics, string values, inline lists, etc.
* removing `[[InitializedIntlObject]]`, we don't use that anymore.
* `[[InitializedPluralRules]]` does not need to be *true*, just need to exist.
* fully specified implementation for `Intl.PluralRules.prototype.resolvedOptions` to avoid ambiguity and arbitrary order of properties.
* re-wording descriptions